### PR TITLE
修复单元测试描述bug，删除多余的断言，格式化。

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,5 +29,6 @@ module.exports = {
         // 不强制链式操作另起一行
         'newline-per-chained-call': ['off'],
         'no-unused-expressions': ['off'],
+        'no-var': ['off'],
     },
 };

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # express-test-util
+
 > test utils for express middlewares (which must call next)
 
 ## Installation
@@ -37,7 +38,7 @@ describe('#default', function () {
 
 });
 ```
+
 ## License
 
 Apache-2.0 © [wangshijun](wangshijun@renrenche.com)
-

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,52 +1,49 @@
-'use strict';
-var path = require('path');
 var gulp = require('gulp');
 var eslint = require('gulp-eslint');
 var excludeGitignore = require('gulp-exclude-gitignore');
 var mocha = require('gulp-mocha');
 var istanbul = require('gulp-istanbul');
-var nsp = require('gulp-nsp');
 var plumber = require('gulp-plumber');
 
 gulp.task('static', function () {
-  return gulp.src('**/*.js')
-    .pipe(excludeGitignore())
-    .pipe(eslint())
-    .pipe(eslint.format())
-    .pipe(eslint.failAfterError());
-});
-
-gulp.task('nsp', function (cb) {
-  nsp({package: path.resolve('package.json')}, cb);
+    return gulp
+        .src('**/*.js')
+        .pipe(excludeGitignore())
+        .pipe(eslint())
+        .pipe(eslint.format())
+        .pipe(eslint.failAfterError());
 });
 
 gulp.task('pre-test', function () {
-  return gulp.src('lib/**/*.js')
-    .pipe(excludeGitignore())
-    .pipe(istanbul({
-      includeUntested: true
-    }))
-    .pipe(istanbul.hookRequire());
+    return gulp
+        .src('lib/**/*.js')
+        .pipe(excludeGitignore())
+        .pipe(
+            istanbul({
+                includeUntested: true,
+            })
+        )
+        .pipe(istanbul.hookRequire());
 });
 
 gulp.task('test', ['pre-test'], function (cb) {
-  var mochaErr;
+    var mochaErr;
 
-  gulp.src('test/**/*.js')
-    .pipe(plumber())
-    .pipe(mocha({reporter: 'spec'}))
-    .on('error', function (err) {
-      mochaErr = err;
-    })
-    .pipe(istanbul.writeReports())
-    .on('end', function () {
-      cb(mochaErr);
-    });
+    gulp.src('test/**/*.js')
+        .pipe(plumber())
+        .pipe(mocha({ reporter: 'spec' }))
+        .on('error', function (err) {
+            mochaErr = err;
+        })
+        .pipe(istanbul.writeReports())
+        .on('end', function () {
+            cb(mochaErr);
+        });
 });
 
 gulp.task('watch', function () {
-  gulp.watch(['lib/**/*.js', 'test/**'], ['test']);
+    gulp.watch(['lib/**/*.js', 'test/**'], ['test']);
 });
 
-gulp.task('prepublish', ['nsp']);
+gulp.task('prepublish');
 gulp.task('default', ['static', 'test']);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "gulp-istanbul": "^1.0.0",
     "gulp-line-ending-corrector": "^1.0.1",
     "gulp-mocha": "^2.0.0",
-    "gulp-nsp": "^2.1.0",
     "gulp-plumber": "^1.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.1.2"

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ describe('#mockRequest', function () {
         expect(req.get).to.be.a('function');
     });
 
-    it('should `req` have custome properties', function () {
+    it('should `req` have custom properties', function () {
         const req = util.mockRequest({
             props: { xxx: 'xxx' },
         });
@@ -56,9 +56,9 @@ describe('#mockRequest', function () {
     });
 });
 
-describe('#mockRequest', function () {
-    it('should have mockRequest method', function () {
-        expect(util.mockRequest).to.be.a('function');
+describe('#mockResponse', function () {
+    it('should have mockResponse method', function () {
+        expect(util.mockResponse).to.be.a('function');
     });
 
     it('should `res` have standard properties', function () {
@@ -75,7 +75,6 @@ describe('#mockRequest', function () {
     it('should `res.cookie` behave as expected', function () {
         const res = util.mockResponse();
 
-        expect(res).to.be.a('object');
         expect(res.cookies).to.be.a('object');
 
         res.cookie('key', 'value');
@@ -85,16 +84,12 @@ describe('#mockRequest', function () {
     it('should `res.status` behave as expected', function () {
         const res = util.mockResponse();
 
-        expect(res).to.be.a('object');
-
         res.status(200);
         expect(res.status).to.equal(200);
     });
 
     it('should `res.send` behave as expected', function () {
         const res = util.mockResponse();
-
-        expect(res).to.be.a('object');
 
         res.send('test');
         expect(res.body).to.equal('test');
@@ -103,16 +98,12 @@ describe('#mockRequest', function () {
     it('should `res.redirect` behave as expected', function () {
         const res = util.mockResponse();
 
-        expect(res).to.be.a('object');
-
         res.redirect('http://www.baidu.com');
         expect(res.redirectUrl).to.equal('http://www.baidu.com');
     });
 
-    it('should `res.redirect` behave as expected', function () {
+    it('should `res.jsonp` behave as expected', function () {
         const res = util.mockResponse();
-
-        expect(res).to.be.a('object');
 
         res.jsonp({ status: 0 });
         expect(res.jsonp).to.deep.equal({ status: 0 });


### PR DESCRIPTION
其它修改:
1. `nsp`和`gulp-nsp`已经被废弃了，做了删除处理；
1. `README.md`的格式化；